### PR TITLE
2016-10-24:  prereq check for ubuntu 16.04, gnome-doc-prepare moved t…

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -78,7 +78,7 @@ esac
 }
 
 (which gnome-doc-prepare && gnome-doc-prepare --force )|| {
-        echo "**Error**: You must have gnome-common installed to compile $PROJECT."
+        echo "**Error**: You must have gnome-common (or gnome-doc-utils) installed to compile $PROJECT."
         exit 1
 }
 


### PR DESCRIPTION
In Ubuntu Xenial, gnome-doc-prepare has been moved to a different package.

`$ lsb_release -a
LSB Version:    core-2.0-amd64:core-2.0-noarch:core-3.0-amd64:core-3.0-noarch:core-3.1-amd64:core-3.1-noarch:core-3.2-amd64:core-3.2-noarch:core-4.0-amd64:core-4.0-noarch:core-4.1-amd64:core-4.1-noarch
Distributor ID: Ubuntu
Description:    Ubuntu 16.04.1 LTS
Release:    16.04
Codename:   xenial
`
